### PR TITLE
Minor fixes

### DIFF
--- a/components/BrRoot.vue
+++ b/components/BrRoot.vue
@@ -55,5 +55,5 @@ export default {
 };
 </script>
 <style lang="scss">
-@import 'app.scss';
+@import './app.scss';
 </style>

--- a/components/Home.vue
+++ b/components/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page
-    class="column gutter-md background"
+    class="column q-col-gutter-md background"
     padding>
     <div class="column items-center">
       <br-setup-wizard

--- a/components/app.less
+++ b/components/app.less
@@ -1,0 +1,4 @@
+/*!
+ * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ */
+@fa-font-path: "@{bedrock-module-path}/@fortawesome/fontawesome-free/webfonts";

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "main": "lib",
   "browser": "index.js",
+  "less": "app.less",
   "scripts": {
     "start": "node --preserve-symlinks setup.localhost.js",
     "postinstall": "node --preserve-symlinks setup.localhost.js compile-less"
@@ -35,6 +36,7 @@
     "vuelidate": "^0.7.4"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "bedrock-test": "^2.0.0",
     "eslint": "^5.12.1",
     "eslint-config-digitalbazaar": "^1.7.0",

--- a/setup.localhost.js
+++ b/setup.localhost.js
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
  */
 const bedrock = require('bedrock');


### PR DESCRIPTION
We still require the less file to set the font awesome path for the font awesome less files.

p.s. we could change the setup of bedrock-setup to use the @fort-awesome *.scss files instead of less. This would allow us to scss variables to the font-awesome paths to the fonts load correctly. might be something for another PR.