### PR TITLE
Bug block next not called

### DIFF
--- a/components/BrSetupWizard.vue
+++ b/components/BrSetupWizard.vue
@@ -23,9 +23,9 @@
           <br-q-form-generator
             ref="form"
             v-model="currentStep.form.model"
-            @input="update"
             :vocab="vocab"
-            :schema="currentStep.form.schema" />
+            :schema="currentStep.form.schema"
+            @input="update" />
         </form>
       </div>
     </br-wizard-step>
@@ -77,7 +77,7 @@ export default {
       config: {},
       review: [],
       stepIndex: 0,
-      updated: Date.now()
+      updated: null
     };
   },
   computed: {

--- a/components/BrSetupWizard.vue
+++ b/components/BrSetupWizard.vue
@@ -23,6 +23,7 @@
           <br-q-form-generator
             ref="form"
             v-model="currentStep.form.model"
+            @input="update"
             :vocab="vocab"
             :schema="currentStep.form.schema" />
         </form>
@@ -75,7 +76,8 @@ export default {
     return {
       config: {},
       review: [],
-      stepIndex: 0
+      stepIndex: 0,
+      updated: Date.now()
     };
   },
   computed: {
@@ -108,6 +110,9 @@ export default {
       return flow;
     },
     blockNext() {
+      if(!this.updated) {
+        return false;
+      }
       if(this.currentStep.form && this.$refs.form && this.$refs.form.$v) {
         return this.$refs.form.$v.$invalid;
       }
@@ -115,6 +120,9 @@ export default {
     }
   },
   methods: {
+    update() {
+      this.updated = Date.now();
+    },
     next() {
       if(this.stepIndex + 1 === this.lastStepIndex) {
         // apply templates for review and config

--- a/setup-example.json
+++ b/setup-example.json
@@ -28,6 +28,7 @@
           "domain": {
             "placeholder": "Your domain",
             "validation": {
+              "minLength": 4,
               "regex": "^(((?!-))(xn--|_{1,1})?[a-z0-9-]{0,61}[a-z0-9]{1,1}.)*(xn--)?([a-z0-9-]{1,61}|[a-z0-9-]{1,30}.[a-z]{2,})$",
               "errors": {
                 "invalid": "The domain you entered is invalid."


### PR DESCRIPTION
Invalid Domain Tests:

1. localhost: -> should not be able to click next
2. loc -> should not be able to click next
3. any valid domain larger then 4 should enable next

The issue is blockNext was not being recomputed when a user
changes the value of a model in bedrock-quasar-form-generator.
The solution is to store the last timestamp of the last change made in a form
and to use that to determine if blockNext should be re-evaluated.

I also tried using [this.$forceUpdate](https://vuejs.org/v2/api/#vm-forceUpdate)()
but this does not cause computed properties to recompute (not sure why).